### PR TITLE
fix: make dependency constraints less strict

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ hyper = { version = "0.14", features = ["client", "http1"] }
 hyper-tls = { version = "0.5", optional = true }
 hyper-rustls = { version = "0.21", optional = true }
 http = "0.2"
-async-trait = "0.1.77"
+async-trait = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firebase-messaging-rs"
-version = "0.8.0"
+version = "0.8.1"
 authors = [
   "Yoichiro ITO <contact.110416@gmail.com>"
 ]
@@ -29,10 +29,10 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = "0.4"
 log = "0.4"
-gcloud-sdk = {version = "0.23", features = ["rest"]}
+gcloud-sdk = {version = "0.24", features = ["rest"]}
 hyper = { version = "0.14", features = ["client", "http1"] }
 hyper-tls = { version = "0.5", optional = true }
-hyper-rustls = { version = "0.21", optional = true }
+hyper-rustls = { version = "0.24", optional = true }
 http = "0.2"
 async-trait = "0.1"
 


### PR DESCRIPTION
close #39 
This commit makes dependency constraint for async-trait less strict on the advice of @rbozan.

See https://github.com/i10416/firebase-messaging-rs/issues/39