### PR TITLE
fix: new could fail if project id is absent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "firebase-messaging-rs"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firebase-messaging-rs"
-version = "0.8.5"
+version = "0.8.6"
 authors = [
   "Yoichiro ITO <contact.110416@gmail.com>"
 ]
@@ -20,14 +20,14 @@ maintenance = { status = "actively-developed" }
 [features]
 default = ["topic-management", "fcm", "native-tls"]
 topic-management = []
-fcm = ["serde_json"]
+fcm = []
 native-tls = ["hyper-tls"]
 rustls = ["hyper-rustls"]
 vendored-tls = ["hyper-tls/vendored"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
-serde_json = { version = "1", optional = true }
+serde_json = { version = "1" }
 chrono = "0.4"
 log = "0.4"
 gcloud-sdk = { version = "0.24", features = ["rest"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,14 +57,18 @@ impl FCMClient {
             .ok()
     }
     pub async fn new() -> Result<Self, String> {
+        #[cfg(feature = "fcm")]
         let project_id = Self::google_cloud_project().ok_or(
-            "cannot detect google project id from env. Provide project id by GOOGLE_CLOUD_PROJECT env var.".to_string(),
+            "Cannot detect google project id from env. Provide project id by GOOGLE_CLOUD_PROJECT env var.".to_string(),
         )?;
+        #[cfg(not(feature = "fcm"))]
+        let project_id = "dummy id for compatibility".to_string();
         FCMClient::with_scope(&project_id, &GCP_DEFAULT_SCOPES).await
     }
     pub async fn new_with_project(project_id: &str) -> Result<Self, String> {
         FCMClient::with_scope(project_id, &GCP_DEFAULT_SCOPES).await
     }
+
     pub async fn with_scope(project_id: &str, scopes: &[String]) -> Result<Self, String> {
         #[cfg(feature = "hyper-tls")]
         let connector = HttpsConnector::new();


### PR DESCRIPTION
Even when the fcm feature is not enabled, it failed to initialize FCMClient instance if it couldn't detect google project id.